### PR TITLE
fix build.properties location

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,0 @@
-sbt.version=0.12.0
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.4
+


### PR DESCRIPTION
`project` の下に置かないと意味ない
